### PR TITLE
Let the browser decide when to show the scrollbar

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -14,7 +14,7 @@
 
 .jp-filetreeWidget {
   background: var(--jp-layout-color1);
-  overflow: scroll;
+  overflow: auto;
   color: var(--jp-ui-font-color1);
   /* This is needed so that all font sizing of children done in ems is
    * relative to this base size */


### PR DESCRIPTION
The scrollbar takes a bit of spaces, we might not want to *always* show it, so it's better to let the browser decide when we need it