### PR TITLE
Replace the core filebrowser

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   },
   "jupyterlab": {
     "extension": true,
-    "outputDir": "jupyterlab_filetree/labextension"
+    "outputDir": "jupyterlab_filetree/labextension",
+    "disabledExtensions": ["@jupyterlab/filebrowser-extension:browser"]
   },
   "styleModule": "style/index.js"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  ILabShell,
   ILayoutRestorer,
   IRouter,
   JupyterFrontEnd,
@@ -20,6 +21,7 @@ function activate(
   restorer: ILayoutRestorer,
   manager: IDocumentManager,
   router: IRouter,
+  labShell: ILabShell,
 ) {
   // eslint-disable-next-line no-console
   console.log("JupyterLab extension jupyterlab_filetree is activated!");
@@ -33,6 +35,7 @@ function activate(
     restorer,
     manager,
     router,
+    labShell,
   );
 }
 
@@ -46,6 +49,7 @@ const extension: JupyterFrontEndPlugin<void> = {
     ILayoutRestorer,
     IDocumentManager,
     IRouter,
+    ILabShell,
   ],
 };
 


### PR DESCRIPTION
This PR is a bit more opinionated than the other ones. It makes the filetree extension the default one.

![default_filetree](https://user-images.githubusercontent.com/21197331/115846029-c9b6ab80-a421-11eb-96b0-08be9674cd00.png)
